### PR TITLE
added marketplace extension installation details

### DIFF
--- a/How-to-Contribute.md
+++ b/How-to-Contribute.md
@@ -142,6 +142,9 @@ The **render** process runs the UI code inside the Shell window. To debug code r
 
 The **extension host** process runs code implemented by a plugin. To debug extensions (including those packaged with Code) which run in the extension host process, you can use VS Code itself. Switch to the Debug viewlet, choose the `Attach to Extension Host` configuration, and press <kbd>F5</kbd>.
 
+#### Debugging VSCode against marketplace extensions
+Open source part of VSCode doesn't include the extension gallery URLs. The recommended way to work with extensions is to download the extension directly and side load using the command line or using __Install from VSIX__ command in the Extensions View command drop-down ([see more](https://code.visualstudio.com/docs/editor/extension-gallery#_command-line-extension-management) on command line extension management).
+
 ### Unit Testing
 Run the tests directly from a terminal by running `./scripts/test.sh` from the `vscode` folder (`scripts\test` on Windows). The [test README](https://github.com/Microsoft/vscode/blob/master/test/README.md) has complete details on how to run and debug tests, as well as how to produce coverage reports.
 


### PR DESCRIPTION
It's confusing that OSS dev mode missing the extension gallery. The are questions about it in issues and stackoverflow. I think it would be helpful to point out the recommended way of working with extensions, so I did a summary of such questions:
[#23831](https://github.com/Microsoft/vscode/issues/23831)
[#30](https://github.com/Microsoft/vscode-wiki/pull/30)

I hope @chrisdias or someone else would provide any feedback.