### PR TITLE
Fix https://github.com/Microsoft/vscode/issues/44291: add docs on debugging search process

### DIFF
--- a/How-to-Contribute.md
+++ b/How-to-Contribute.md
@@ -90,7 +90,7 @@ You can identify the development version of Code by the Electron icon in the Doc
 **Tip!** If you receive an error stating that the app is not a valid Electron app, it probably means you didn't run `yarn run watch` first.
 
 ### Debugging
-Code has a multi-process architecture and your code is executed in different processes. See the `.vscode/launch.json` file in the vscode for various process debug configurations.
+Code has a multi-process architecture and your code is executed in different processes.
 
 The **render** process runs the UI code inside the Shell window. To debug code running in the **render** you can either use VS Code or the Chrome Developer Tools.
 
@@ -109,7 +109,7 @@ The **render** process runs the UI code inside the Shell window. To debug code r
 
 The **extension host** process runs code implemented by a plugin. To debug extensions (including those packaged with Code) which run in the extension host process, you can use VS Code itself. Switch to the Debug viewlet, choose the `Attach to Extension Host` configuration, and press <kbd>F5</kbd>.
 
-The **search** process can be debugged, but must first be started.  Before attempting to attach, start a search (use `ctrl+p` or `cmd+p`) to get the process running, otherwise you will timeout trying to attach.
+The **search** process can be debugged, but must first be started. Before attempting to attach, start a search (e.g. with `ctrl+p` or `cmd+p`) to start the process, otherwise attaching will fail and time out.
 
 ### Automated Testing
 Run the unit tests directly from a terminal by running `./scripts/test.sh` from the `vscode` folder (`scripts\test` on Windows). The [test README](https://github.com/Microsoft/vscode/blob/master/test/README.md) has complete details on how to run and debug tests, as well as how to produce coverage reports.

--- a/How-to-Contribute.md
+++ b/How-to-Contribute.md
@@ -90,7 +90,7 @@ You can identify the development version of Code by the Electron icon in the Doc
 **Tip!** If you receive an error stating that the app is not a valid Electron app, it probably means you didn't run `yarn run watch` first.
 
 ### Debugging
-Code has a multi-process architecture and your code is executed in different processes.
+Code has a multi-process architecture and your code is executed in different processes. See the `.vscode/launch.json` file in the vscode for various process debug configurations.
 
 The **render** process runs the UI code inside the Shell window. To debug code running in the **render** you can either use VS Code or the Chrome Developer Tools.
 
@@ -108,6 +108,8 @@ The **render** process runs the UI code inside the Shell window. To debug code r
 [![sourcemaps](http://i.imgur.com/KU3TdjO.png)](http://i.imgur.com/KU3TdjO.png)
 
 The **extension host** process runs code implemented by a plugin. To debug extensions (including those packaged with Code) which run in the extension host process, you can use VS Code itself. Switch to the Debug viewlet, choose the `Attach to Extension Host` configuration, and press <kbd>F5</kbd>.
+
+The **search** process can be debugged, but must first be started.  Before attempting to attach, start a search (use `ctrl+p` or `cmd+p`) to get the process running, otherwise you will timeout trying to attach.
 
 ### Automated Testing
 Run the unit tests directly from a terminal by running `./scripts/test.sh` from the `vscode` folder (`scripts\test` on Windows). The [test README](https://github.com/Microsoft/vscode/blob/master/test/README.md) has complete details on how to run and debug tests, as well as how to produce coverage reports.


### PR DESCRIPTION
Fixes https://github.com/Microsoft/vscode/issues/44291, adding a few notes about debugging/attaching to processes.