### PR TITLE
Update cross-compile steps to add yarn workarounds

### DIFF
--- a/Cross-Compiling-for-Debian-Based-Linux.md
+++ b/Cross-Compiling-for-Debian-Based-Linux.md
@@ -36,19 +36,19 @@ Because cross-compiling isn't officially supported by the VSCode team, some work
 1. Remove the `yarn` check, since `yarn` doesn't currently support cross-compiling:
 
    ```bash
-   rm build/npm/preinstall.js
-   touch build/npm/preinstall.js
+   echo > build/npm/preinstall.js
    ```
 
-1. Install prerequisites for the target architecture using `npm` (:
+1. Set the electron version and install prerequisites for the target architecture using `npm` (instead of `yarn`):
 
    ```bash
-   npm i --target_arch=armhf
+   export npm_config_target="$(grep target .yarnrc | sed 's/[^0-9.]*//g')"
+   npm install --target_arch=armhf
    ```
 
-1. Build VSCode and create a .deb file for easy installation on the target device:
+1. Build VSCode and create a .deb file (for easier installation on the target device) as usual:
 
    ```bash
-   gulp vscode-linux-arm-min
-   gulp vscode-linux-arm-build-deb
+   yarn run gulp vscode-linux-arm-min
+   yarn run gulp vscode-linux-arm-build-deb
    ```

--- a/Cross-Compiling-for-Debian-Based-Linux.md
+++ b/Cross-Compiling-for-Debian-Based-Linux.md
@@ -1,45 +1,54 @@
-To build for a target architecture different than the host (e.g. using x64 to build for ARM), you'll need to do the following:
+To build for a target architecture different than the host (e.g. using x64 to build for ARM), you'll need to do the following, in addition to the setup under [How to Contribute](https://github.com/Microsoft/vscode/wiki/How-to-Contribute):
 
 **One-Time Setup**
 
-1. install prerequisites:
+1. Install build toolchain and chroot/rootfs prerequisites:
 
-   ```
+   ```bash
    sudo apt-get install qemu qemu-user-static debootstrap gcc-arm-linux-gnueabihf g++-arm-linux-gnueabihf
    ```
 
-2. create a chroot/rootfs for the target architecture:
+1. Create a chroot/rootfs for the target architecture:
 
-   ```
+   ```bash
    sudo qemu-debootstrap --arch=armhf --variant=minbase xenial rootfs
    ```
 
-3. install libx11-dev on the chroot/rootfs:
+1. Install libx11-dev on the chroot/rootfs:
 
-   ```
+   ```bash
    sudo chroot rootfs apt-get install -y libx11-dev
    ```
 
 **Build**
 
-1. point to the target toolchain on the build host:
+Because cross-compiling isn't officially supported by the VSCode team, some workarounds are required to make the app build correctly:
 
-   ```
+1. Point to the target toolchain on the build host:
+
+   ```bash
    export CC=$(which arm-linux-gnueabihf-gcc)
    export CXX="$(which arm-linux-gnueabihf-g++) -L$(pwd)/rootfs/usr/lib/arm-linux-gnueabihf/"
    ```
 
    *note the -L linker argument pointing to the absolute path of libx11 on the chroot/rootfs*
+   
+1. Remove the `yarn` check, since `yarn` doesn't currently support cross-compiling:
 
-2. install prerequisites for the target architecture:
-
+   ```bash
+   rm build/npm/preinstall.js
+   touch build/npm/preinstall.js
    ```
-   yarn --arch=armhf
+
+1. Install prerequisites for the target architecture using `npm` (:
+
+   ```bash
+   npm i --target_arch=armhf
    ```
 
-3. create a .deb file for easy installation on the target device:
+1. Build VSCode and create a .deb file for easy installation on the target device:
 
-   ```
-   yarn run gulp vscode-linux-arm-min
-   yarn run gulp vscode-linux-arm-build-deb
+   ```bash
+   gulp vscode-linux-arm-min
+   gulp vscode-linux-arm-build-deb
    ```


### PR DESCRIPTION
`yarn` doesn't currently support cross-compiling native components, see https://github.com/yarnpkg/yarn/issues/2221

I have updated the wiki page to include the correct steps for cross-compiling VSCode.