### PR TITLE
Added prerequisite for Windows building - ASCII Windows profile path

### DIFF
--- a/How-to-Contribute.md
+++ b/How-to-Contribute.md
@@ -21,6 +21,7 @@ git clone https://github.com/Microsoft/vscode.git
 - [Python](https://www.python.org/downloads/), at least version 2.7 (version 3 is __*not*__ supported)
 - C/C++ compiler tool chain
   - **Windows**
+    - Make sure your profile path only contains ACSII letters, eg *John*, otherwise it can lead to [node-gyp usage problems (nodejs/node-gyp/issues#297)](https://github.com/nodejs/node-gyp/issues/297)
     - Set a `PYTHON` environment variable pointing to your `python.exe`. Eg: `C:\Python27\python.exe`
     - [Visual Studio Community 2017](https://www.visualstudio.com/downloads/), make sure to select the option to install all C++ tools and the Windows SDK. Alternatively, you can also use Felix Rieseberg's [Windows Build Tools npm module](https://github.com/felixrieseberg/windows-build-tools) instead of Visual Studio 2017. The `--debug` flag is helpful if you encounter any problems during installation.
     - Please note that building and debugging via the Windows subsystem for Linux (WSL) is currently not supported.


### PR DESCRIPTION
Hello, ive forked VSCode project, followed guidlines for contributing and could not build it with 
```
cd vscode
yarn
```

Apparently, i found that it was a problem with my Windows profile name, it was cyrillic. After i renamed it with latinic letters, all problems were gone. 

So i suggest to add this line to wiki, so other people wont loose time like a did
> - Make sure your profile path only contains ACSII letters, eg *John*, otherwise it can lead to [node-gyp usage problems (nodejs/node-gyp/issues#297)](https://github.com/nodejs/node-gyp/issues/297)