### PR TITLE
Update ARM cross-compilation instructions

### DIFF
--- a/Cross-Compiling-for-Debian-Based-Linux.md
+++ b/Cross-Compiling-for-Debian-Based-Linux.md
@@ -32,23 +32,17 @@ Because cross-compiling isn't officially supported by the VSCode team, some work
    ```
 
    *note the -L linker argument pointing to the absolute path of libx11 on the chroot/rootfs*
+
+1. Tell `yarn` you want to cross-compile native modules for ARM:
    
-1. Remove the `yarn` check, since `yarn` doesn't currently support cross-compiling:
-
    ```bash
-   echo > build/npm/preinstall.js
-   ```
-
-1. Set the electron version and install prerequisites for the target architecture using `npm` (instead of `yarn`):
-
-   ```bash
-   export npm_config_target="$(grep target .yarnrc | sed 's/[^0-9.]*//g')"
-   npm install --target_arch=armhf
+   export npm_config_arch=arm
    ```
 
 1. Build VSCode and create a .deb file (for easier installation on the target device) as usual:
 
    ```bash
+   yarn
    yarn run gulp vscode-linux-arm-min
    yarn run gulp vscode-linux-arm-build-deb
    ```

--- a/How-to-Contribute.md
+++ b/How-to-Contribute.md
@@ -45,7 +45,7 @@ cd vscode
 yarn
 ```
 
-If you are on Windows or Linux 64 bit systems and would like to compile to 32 bits, you'll need to set the `npm_config_arch` environment to `ia32` before running `yarn`. This will compile all native node modules for a 32 bit architecture.
+If you are on Windows or Linux 64 bit systems and would like to compile to 32 bits, you'll need to set the `npm_config_arch` environment variable to `ia32` before running `yarn`. This will compile all native node modules for a 32 bit architecture. Similarly, when cross-compiling for ARM, set `npm_config_arch` to `arm`.
 
 **Note:** For more information on how to install NPM modules globally on UNIX systems without resorting to `sudo`, refer to [this guide](http://www.johnpapa.net/how-to-use-npm-global-without-sudo-on-osx/).
 


### PR DESCRIPTION
The instructions for cross-compiling became out-of-date shortly after VSCode switched from `npm` to `yarn`, around v1.21. This PR updates documentation to include more appropriate instructions for newer versions, Tested successfully this morning against 1.27.1.