### PR TITLE
Add paragraph about claiming issues in How-to-Contribute

### DIFF
--- a/How-to-Contribute.md
+++ b/How-to-Contribute.md
@@ -139,6 +139,8 @@ Check out the [full issues list](https://github.com/Microsoft/vscode/issues?utf8
 
 To improve the chances to get a pull request merged you should select an issue that is labelled with the [`help-wanted`](https://github.com/Microsoft/vscode/issues?q=is%3Aopen+is%3Aissue+label%3A%22help+wanted%22) or [`bug`](https://github.com/Microsoft/vscode/issues?q=is%3Aopen+is%3Aissue+label%3A%22bug%22) labels. If the issue you want to work on is not labelled with `help-wanted` or `bug`, you can start a conversation with the issue owner asking whether an external contribution will be considered.
 
+To avoid multiple pull requests resolving the same issue, let others know you are working on it by saying so in a comment.
+
 ## Packaging
 
 Code can be packaged for the following platforms: `win32-ia32 | win32-x64 | darwin | linux-ia32 | linux-x64 | linux-arm`


### PR DESCRIPTION
Resolves #58 

Add paragraph in `Where to Contribute` section of How-to-Contribute.md to tell outside contributors to make a comment on the issue for which they are working on a pull request.