### PR TITLE
<kbd> & snippet tagging

### DIFF
--- a/Performance-Issues.md
+++ b/Performance-Issues.md
@@ -81,23 +81,23 @@ Run VS Code in verbose mode and check whether there is any suspicious output in 
 When you cannot share the workspace exposing the problem with us, then you can help us by providing performance profiles that we can analyze:
 
 Finally, please create a CPU profile of the VS Code core (_renderer_ process) and attach it to the issue. To create a profile:
-  -  Execute "F1 > Toggle Developer Tools." In the overflow menu of the developer tools <img width="380" alt="screen shot 2017-09-28 at 09 44 31" src="https://user-images.githubusercontent.com/1794099/30954796-d1be9e30-a431-11e7-959e-495d234c37c6.png">
+  -  Execute "<kbd>F1</kbd> > Toggle Developer Tools." In the overflow menu of the developer tools <img width="380" alt="screen shot 2017-09-28 at 09 44 31" src="https://user-images.githubusercontent.com/1794099/30954796-d1be9e30-a431-11e7-959e-495d234c37c6.png">
   - Select 'More Tools > JavaScript Profiler'. In there select start.
   - Let it profile for 30 to 60 seconds, stop it.
-  - When the performance issue happens on startup, start the profiler and then reload the window using "F1>Reload Window."
+  - When the performance issue happens on startup, start the profiler and then reload the window using "<kbd>F1</kbd> > Reload Window."
   - Save the profile to a file and attach the file to your issue.
 
 ## Visual Studio Code starts up slowly
 
 If VS Code is slow to start then please create a startup CPU profile. Do the following
   - Make sure to only have one window open
-  - Quit VS Code (Cmd+Q for Mac, closing the last window on Linux/Windows)
+  - Quit VS Code (<kbd>CMD+Q</kbd> for Mac, closing the last window on Linux/Windows)
   - Start VS Code from the command line like so `code --prof-startup`
   - VS Code will start and create two profile-files in your home-directory. Please attach these files to your issue or create a new issue with these two files
 
 ### Read the Startup Timers
 
-When VS Code feels slow to start, you can check the startup timers. Hit "F1" and select "Startup Performance." This will open developer tools and print some startup stats onto the "Console."
+When VS Code feels slow to start, you can check the startup timers. Hit <kbd>F1</kbd> and select "Startup Performance." This will open developer tools and print some startup stats onto the "Console."
 
 ![image](https://user-images.githubusercontent.com/172399/32089769-3df19924-baec-11e7-9654-e199e1ab8c92.png)
 

--- a/Search-Issues.md
+++ b/Search-Issues.md
@@ -1,6 +1,6 @@
 # Search Issues
 
-This document applies to search (`cmd+shift+f`/`ctrl+shift+f`) and quickopen (`cmd+p`/`ctrl+p`). By default, VS Code uses the [ripgrep](https://github.com/BurntSushi/ripgrep) tool to drive search. Learn more about how to use search in [the documentation](https://code.visualstudio.com/docs/editor/codebasics#_search-across-files).
+This document applies to search (<kbd>CMD+SHIFT+F</kbd>/<kbd>CTRL+SHIFT+F</kbd>) and quickopen (<kbd>CMD+P</kbd>/<kbd>CTRL+P</kbd>). By default, VS Code uses the [ripgrep](https://github.com/BurntSushi/ripgrep) tool to drive search. Learn more about how to use search in [the documentation](https://code.visualstudio.com/docs/editor/codebasics#_search-across-files).
 
 ## Missing search results
 

--- a/Smoke-Test.md
+++ b/Smoke-Test.md
@@ -64,7 +64,7 @@ This task is about verifying how a first launch behaves for new users that never
 * Verify that "Go to line" works (ctrl+g)
 
 #### Search
-* Use Search (CTRL+SHIFT+F, ⌘+SHIFT+F) to find `body`
+* Use Search (<kbd>CTRL+SHIFT+F</kbd>, <kbd>⌘+SHIFT+F</kbd>) to find `body`
   * Verify that 14 results in 5 files show up
   * Verify you can run the search filtering for `*.js` files
   * Verify you can dismiss files from search results
@@ -77,7 +77,7 @@ This task is about verifying how a first launch behaves for new users that never
 
 #### CSS
 * Open file style.css
-  * verify quick outline (CTRL-SHIFT-O, ⌘-SHIFT-O)
+  * verify quick outline (<kbd>CTRL+SHIFT+O</kbd>, (<kbd>⌘+SHIFT+O</kbd>)
 * Add an empty rule `.foo{}`
   * verify you can see a warning in the editor
   * verify you can see a warning from the Problems view
@@ -92,7 +92,7 @@ This task is about verifying how a first launch behaves for new users that never
 
 #### JavaScript
 * Open `bin/www`
-  * Show the quick outline (CTRL-SHIFT-O, ⌘-SHIFT-O) verify that entries show up and make sense
+  * Show the quick outline (<kbd>CTRL+SHIFT+O</kbd>, <kbd>⌘+SHIFT+O</kbd>) verify that entries show up and make sense
   * From the context select Find All References to `app`
   * From context menu use Rename Symbol to rename a local variable
   * Verify code folding works
@@ -106,7 +106,7 @@ This task is about verifying how a first launch behaves for new users that never
   * make sure that VSCode automatically detects ${workspaceRoot}/bin/www as the 'program' attribute
   * add `"protocol": "inspector"` to `launch.json`
 * set a breakpoint in index.js:6
-* press F5 to start debugging. Verify:
+* press <kbd>F5</kbd> to start debugging. Verify:
   * workbench transforms into "debug mode" - glyph margin and status bar turns orange
 * open browser at http://localhost:3000/
   * verify the breakpoint in index.js gets hit
@@ -130,7 +130,7 @@ This task is about verifying how a first launch behaves for new users that never
 
 #### Integrated Terminal
 * Open the integrated terminal
-* Run a command and verify the output makes sense (e.g. ls or dir)
+* Run a command and verify the output makes sense (e.g. `ls` or `dir`)
 
 #### Status bar
 * Quickly click on all the actions in the status bar and verify they behave as expected
@@ -144,11 +144,11 @@ This task is about verifying how a first launch behaves for new users that never
 #### Accessibility
 * Turn on
   * OS X: Voice Over
-  * Windows: nvda, command palette > 'Toggle Tab Key Moves Focus' (CTRL+M)
+  * Windows: nvda, command palette > 'Toggle Tab Key Moves Focus' (<kbd>CTRL+M</kbd>)
   * Linux: n/a
 * Tab through the whole workbench and verify what you hear makes sense. Also verify you can tab back into the location from where you started
 * Check high contrast theme
 
 #### Localization
-* Start code from the command line with --locale=DE
+* Start code from the command line with `--locale=DE`
 * Verify all menus and viewlets are in German (or your language of choice)

--- a/Terminal-Issues.md
+++ b/Terminal-Issues.md
@@ -13,13 +13,13 @@ For some terminal issues it's useful to get trace logs, this can reveal at what 
 1. Close all VS Code windows
 2. Launch VS Code from the terminal using `code --log trace`
 3. At this point you should reproduce the terminal issue you're having
-4. Run the command "Developer: Open Log File..." (F1 opened command palette) to get an editor containing the logs
+4. Run the command "Developer: Open Log File..." (<kbd>F1</kbd> opened command palette) to get an editor containing the logs
 
 ### Enabling escape sequence logging
 
 This was added in v1.26.
 
-For issues where text is misbehaving in the terminal you can enable logging of the data being sent to the emulator from the shell process. To enable escape sequence logging run the "Terminal: Toggle Escape Sequence Logging" command from the command palette (F1), the logs can then be viewed in the devtools console (Help &gt; Toggle Developer Tools).
+For issues where text is misbehaving in the terminal you can enable logging of the data being sent to the emulator from the shell process. To enable escape sequence logging run the "Terminal: Toggle Escape Sequence Logging" command from the command palette (<kbd>F1</kbd>), the logs can then be viewed in the devtools console (Help &gt; Toggle Developer Tools).
 
 ### Long standing known issues
 


### PR DESCRIPTION
This PR fixes ignored tagging throughout the Wiki's files, turning things such as "Ctrl+Q" into <kbd>CTRL+Q</kbd>, to take advantage of GitHub's `<kbd>` tag formatting while also maintaining patterns.

A minor amount of code snippets were also formatted in `Smoke-Test.md`.