### PR TITLE
 Capitalize outer bullet list items and fix typos 

### DIFF
--- a/Smoke-Test.md
+++ b/Smoke-Test.md
@@ -39,7 +39,7 @@ This task is about running the new version over the same data of the stable rele
 
 #### First User Experience
 
-This task is about verifying how a first launch behaves for new users that have never started Code before.
+This task is about verifying how a first launch behaves for new users who have never started Code before.
 * Delete the user-data-dir and extensions dir from previous steps
 * Run `code-insiders --user-data-dir <data dir> --extensions-dir <extensions dir> <vscode-smoketest-express-folder>`
 * Verify you see a welcome page and the experience is pleasant

--- a/Smoke-Test.md
+++ b/Smoke-Test.md
@@ -1,4 +1,4 @@
-This page describes the VS Code Smoke test, an automatic and a manual test cases that we execute before we release VS Code to the public on all platforms.
+This page describes the VS Code Smoke test, an automatic and a manual test suite that we execute before we release VS Code to the public on all platforms.
 
 ## Automated Smoke Test
 
@@ -25,7 +25,7 @@ https://github.com/Microsoft/vscode/blob/master/test/smoke/README.md
 
 This task is about running the new version over the same data of the stable released version. Specifically we want to see that the new version is starting up properly, restores all state including dirty files from a previous session.
 
-* run `code-insiders --user-data-dir <data dir from prereq step> --extensions-dir <extensions dir from prereq step> <vscode-smoketest-express-folder>`
+* Run `code-insiders --user-data-dir <data dir from prereq step> --extensions-dir <extensions dir from prereq step> <vscode-smoketest-express-folder>`
 * Verify the new version of VS Code starts properly and all of the UI state is restored from when you used stable in the previous step
 * Verify dirty files and untitled are being restored (hot exit)
 
@@ -39,14 +39,14 @@ This task is about running the new version over the same data of the stable rele
 
 #### First User Experience
 
-This task is about verifying how a first launch behaves for new users that never started Code before.
-* delete the user-data-dir and extensions dir from previous steps
-* run `code-insiders --user-data-dir <data dir> --extensions-dir <extensions dir> <vscode-smoketest-express-folder>`
-* verify you see a welcome page and the experience is pleasant
+This task is about verifying how a first launch behaves for new users that have never started Code before.
+* Delete the user-data-dir and extensions dir from previous steps
+* Run `code-insiders --user-data-dir <data dir> --extensions-dir <extensions dir> <vscode-smoketest-express-folder>`
+* Verify you see a welcome page and the experience is pleasant
 
 #### Explorer
 
-* launch VSCode and open the vscode-smoketest-express folder
+* Launch VSCode and open the vscode-smoketest-express folder
 * On the desktop create an info.txt file
 * Drag it to the explorer then rename it to README.txt
 * Move README.txt to another folder and then delete it and verify it ends up in the trash
@@ -101,14 +101,14 @@ This task is about verifying how a first launch behaves for new users that never
   * Format the code
 
 #### Debugging JavaScript
-* in VSCode switch to debugging viewlet
+* In VSCode switch to debugging viewlet
 * Click on the gear to create a default launch.json file:
   * make sure that VSCode automatically detects ${workspaceRoot}/bin/www as the 'program' attribute
   * add `"protocol": "inspector"` to `launch.json`
-* set a breakpoint in index.js:6
-* press <kbd>F5</kbd> to start debugging. Verify:
+* Set a breakpoint in index.js:6
+* Press <kbd>F5</kbd> to start debugging. Verify:
   * workbench transforms into "debug mode" - glyph margin and status bar turns orange
-* open browser at http://localhost:3000/
+* Open browser at http://localhost:3000/
   * verify the breakpoint in index.js gets hit
 * Verify step over, step in, continue work
 * While stopped, verify:


### PR DESCRIPTION
Typos fixed:
* "a test cases" -> "a test suite" (line 1)
* "users that never started" -> "users who have never started" (line 42)