### PR TITLE
Include command line instructions for windows-build-tools

### DIFF
--- a/How-to-Contribute.md
+++ b/How-to-Contribute.md
@@ -22,7 +22,7 @@ git clone https://github.com/Microsoft/vscode.git
 - C/C++ compiler tool chain
   - **Windows**
     - Set a `PYTHON` environment variable pointing to your `python.exe`. Eg: `C:\Python27\python.exe`
-    - Use Felix Rieseberg's [Windows Build Tools npm module](https://github.com/felixrieseberg/windows-build-tools) with the **`--vs2015`** parameter ([documentation](https://github.com/felixrieseberg/windows-build-tools#visual-studio-2017-vs-visual-studio-2015)). The `--debug` flag is helpful if you encounter any problems during installation.
+    - Use Felix Rieseberg's [Windows Build Tools npm module](https://github.com/felixrieseberg/windows-build-tools) ([documentation](https://github.com/felixrieseberg/windows-build-tools#visual-studio-2017-vs-visual-studio-2015)). The `--debug` flag is helpful if you encounter any problems during installation. `npm install --global windows-build-tools`
     - **Restart** your computer
     - **Warning:** Make sure your profile path only contains ASCII letters, eg *John*, otherwise it can lead to [node-gyp usage problems (nodejs/node-gyp/issues#297)](https://github.com/nodejs/node-gyp/issues/297)
     - **Note**: Building and debugging via the Windows subsystem for Linux (WSL) is currently not supported.


### PR DESCRIPTION
Fixes #26 

Added the command to install Windows Build Tools, removed the --vs2015 parameter as by default omitting it installs it for 2017 which is lighter than 2015 and more recent.