### PR TITLE
Improved Linux Uninstall Instructions

### DIFF
--- a/Removing-Insiders.md
+++ b/Removing-Insiders.md
@@ -19,3 +19,7 @@ GUI Based: Navigate to Control Panel -> Programs -> Program and Features. Search
 ## Linux
 
 Remove `.deb` or `.rpm` package. 
+- For Debian and Ubuntu
+`sudo apt-get purge code-insiders`
+- For Red Hat, CentOS and SUSE 
+`sudo yum remove code-insiders`

--- a/Removing-Insiders.md
+++ b/Removing-Insiders.md
@@ -18,8 +18,14 @@ GUI Based: Navigate to Control Panel -> Programs -> Program and Features. Search
 
 ## Linux
 
-Remove `.deb` or `.rpm` package. 
-- For Debian and Ubuntu
-`sudo apt-get purge code-insiders`
-- For Red Hat, CentOS and SUSE 
-`sudo yum remove code-insiders`
+To remove the `.deb` package (Debian and Ubuntu):
+
+```
+sudo apt-get purge code-insiders
+```
+
+To remove the `.rpm` package (Red Hat, CentOS and SUSE):
+
+```
+sudo yum remove code-insiders
+```


### PR DESCRIPTION
The Uninstall instruction for Linux was very short and for newbie's, it was not easy. This commit adds the copy/paste command for uninstall in Linux Section.