### PR TITLE
Add GConf2 dependency to build instructions

### DIFF
--- a/How-to-Contribute.md
+++ b/How-to-Contribute.md
@@ -45,12 +45,15 @@ git clone https://github.com/Microsoft/vscode.git
   - **Linux**
     * `make`
     * [GCC](https://gcc.gnu.org) or another compile toolchain
-    * [native-keymap](https://www.npmjs.com/package/native-keymap) needs `libx11-dev` and `libxkbfile-dev`.
+    * `libx11-dev` and `libxkbfile-dev` are required by [native-keymap](https://www.npmjs.com/package/native-keymap):
       * On Debian-based Linux: `sudo apt-get install libx11-dev libxkbfile-dev`
       * On Red Hat-based Linux: `sudo yum install libX11-devel.x86_64 libxkbfile-devel.x86_64 # or .i686`.
-    * [keytar](https://www.npmjs.com/package/keytar) needs `libsecret-1-dev`.
+    * `libsecret-1-dev` is required by [keytar](https://www.npmjs.com/package/keytar):
       * On Debian-based Linux: `sudo apt-get install libsecret-1-dev`.
       * On Red Hat-based Linux: `sudo yum install libsecret-devel`.
+    * `libgconf-2` is required by [electron](https://electronjs.org/):
+      * On Debian-based Linux: `sudo apt-get install libgconf-2-4`.
+      * On Red Hat-based Linux: `sudo yum install GConf2`.
     * Building deb and rpm packages requires `fakeroot` and `rpm`, run: `sudo apt-get install fakeroot rpm`
 
 Finally, install all dependencies using `Yarn`:


### PR DESCRIPTION
There appears to be a runtime dependency on GConf2 when running on Linux:

* Microsoft/vscode#43801
* Microsoft/vscode#24945
* Microsoft/vscode#16015

This has been added to the rpm (Microsoft/vscode@d9f50bdfce5cb22677bd44921d681b9cdc49a8ea) and deb (Microsoft/vscode@43e059e651df6863ec39b5161c0f8c9e1c0c6653) packages, but is absent from the build instructions.

Given that some (many?) major distributions (i.e. Ubuntu) no longer ship GConf2 by default, adding this to the build instructions may be beneficial to a significant number of contributors.

I also reordered the wording of the linux dependencies to have the library first, followed by the component. This seemed clearer and more in line with the preceding lines (i.e. make, gcc).