### PR TITLE
Fix wrong range of node version for vscode-node-debug2 in table

### DIFF
--- a/Related-Projects.md
+++ b/Related-Projects.md
@@ -5,7 +5,7 @@ The Code project consists of the `vscode` repository plus a number of satellite 
 |---|---|
 |Standalone Monaco Editor|[monaco-editor](https://github.com/Microsoft/monaco-editor)|
 |Node Debug (for node < v8.0)|[vscode-node-debug](https://github.com/microsoft/vscode-node-debug)|
-|Node Debug (for node >= v6.3)|[vscode-node-debug2](https://github.com/microsoft/vscode-node-debug2)|
+|Node Debug (for node >= v8.0)|[vscode-node-debug2](https://github.com/microsoft/vscode-node-debug2)|
 |Chrome Debug Core| [vscode-chrome-debug-core](https://github.com/Microsoft/vscode-chrome-debug-core)|
 |File Watcher|[vscode-filewatcher-windows](https://github.com/microsoft/vscode-filewatcher-windows)|
 |`vscode.d.ts`|[vscode-extension-code](https://github.com/microsoft/vscode-extension-vscode)|


### PR DESCRIPTION
On the [Related Projects](https://github.com/Microsoft/vscode/wiki/Related-Projects) page, in the Core Repositories table, there is this line : Node Debug (for node >= v6.3) | vscode-node-debug2.

The version range is **>= 6.3** while it should be **>= 8.0** as mentioned on the main page of the link [vscode-node-debug2](https://github.com/microsoft/vscode-node-debug2).

I replaced >= 6.3 by >= 8.0 which seems to be more coherent.