### PR TITLE
Update link for Debug Diagnostic Tool

### DIFF
--- a/Native-Crash-Issues.md
+++ b/Native-Crash-Issues.md
@@ -18,7 +18,7 @@ It should look something like this:
 
 ## Windows
 On Windows, you will need to install a program in order to collect more information when a crash occurs.
-* download & install [Debug Diagnostic Tools for Windows](https://www.microsoft.com/en-us/download/details.aspx?id=49924) (pick the `DebugDiagx64.msi` option)
+* download & install [Debug Diagnostic Tools for Windows](https://www.microsoft.com/en-us/download/details.aspx?id=58210) (pick the `DebugDiagx64.msi` option)
 * run `DebugDiag 2 Collection`
 * select to capture crash dumps:
 


### PR DESCRIPTION
There has been a newer version of Debug Diagnostic Tool (v2 update 3) available at <https://www.microsoft.com/en-us/download/details.aspx?id=58210>, so I changed the previous link (Debug Diagnostic Tool v2 Update 2) to this link.