### PR TITLE
fix missing link of npm Scripts

### DIFF
--- a/Related-Projects.md
+++ b/Related-Projects.md
@@ -68,7 +68,7 @@ The Code project consists of the `vscode` repository plus a number of satellite 
 ## NPM
 |Repository|
 |---|
-|npm Scripts |[vscode-npm-scripts](https://github.com/Microsoft/vscode-npm-scripts)
+|[vscode-npm-scripts](https://github.com/Microsoft/vscode-npm-scripts)
 
 ## Keybindings
 |Tool|Repository|


### PR DESCRIPTION
I was reading through https://github.com/Microsoft/vscode/wiki/Related-Projects and I saw that `npm Scripts` is not linked.
I followed the format that **Themes** is written.