### PR TITLE
Updated tslint extension link (deprecated)

### DIFF
--- a/How-to-Contribute.md
+++ b/How-to-Contribute.md
@@ -166,7 +166,7 @@ Run the tests directly from a terminal by running `./scripts/test.sh` from the `
 ### Linting
 We use [tslint](https://github.com/palantir/tslint) for linting our sources. You can run tslint across the sources by calling `gulp tslint` from a terminal or command prompt. You can also run `gulp tslint` as a Code task by pressing <kbd>CMD+P</kbd> (<kbd>CTRL+P</kbd> on Windows) and entering `task tslint`. Warnings from tslint show up in the `Errors and Warnings` quick box and you can navigate to them from inside Code.
 
-To lint the source as you make changes you can install the [tslint extension](https://marketplace.visualstudio.com/items/eg2.tslint).
+To lint the source as you make changes you can install the [tslint extension](https://marketplace.visualstudio.com/items/ms-vscode.vscode-typescript-tslint-plugin).
 
 ### Extensions
 The Visual Studio Marketplace is not available from the `vscode` open source builds. If you need to use or debug an extension you can check to see if the extension author publishes builds in their repository (check the `Builds` page) or if it is open source you can clone and build the extension locally. Once you have the .VSIX, you can "side load" the extension either through the command line or using __Install from VSIX__ command in the Extensions View command drop-down ([see more](https://code.visualstudio.com/docs/editor/extension-gallery#_command-line-extension-management) on command line extension management).


### PR DESCRIPTION
Updated tslint extension link because [current extension](https://marketplace.visualstudio.com/items/eg2.tslint) has been deprecated in favor of the [vscode-typescript-tslint-plugin](https://marketplace.visualstudio.com/items/ms-vscode.vscode-typescript-tslint-plugin).