### PR TITLE
Add dev container info to "How to Contribute"

### DIFF
--- a/How-to-Contribute.md
+++ b/How-to-Contribute.md
@@ -71,7 +71,7 @@ Alternatively, you can avoid local dependency installation as this repository in
 - For [Remote - Containers](https://aka.ms/vscode-remote/download/containers), use the **Remote-Containers: Open Repository in Container...** command which creates a Docker volume for better disk I/O on macOS and Windows.
 - For Codespaces, install the [Visual Studio Codespaces](https://aka.ms/vscs-ext-vscode) extension in VS Code, and use the **Codespaces: Create New Codespace** command.
 
-Docker / the Codespace should have at least **4 Cores and 6 GB of RAM (8 GB recommended)** to run full build. See the [development container README](https://github.com/microsoft/vscode/blob/master/.devcontainer/README.md) for more information.
+Docker / the Codespace should have at least **4 Cores and 6 GB of RAM (8 GB recommended)** to run the full build. See the [development container README](https://github.com/microsoft/vscode/blob/master/.devcontainer/README.md) for more information.
 
 If you'd like to contribute to the list of available development containers in the Remote - Containers extension, you can check out the [Contributing documentation](https://github.com/microsoft/vscode-dev-containers/blob/master/CONTRIBUTING.md) in the vscode-dev-containers repo.
 

--- a/How-to-Contribute.md
+++ b/How-to-Contribute.md
@@ -73,6 +73,8 @@ Alternatively, you can avoid local dependency installation as this repository in
 
 Docker / the Codespace should have at least **4 Cores and 6 GB of RAM (8 GB recommended)** to run full build. See the [development container README](https://github.com/microsoft/vscode/blob/master/.devcontainer/README.md) for more information.
 
+If you'd like to contribute to the list of available development containers in the Remote - Containers extension, you can check out the [Contributing documentation](https://github.com/microsoft/vscode-dev-containers/blob/master/CONTRIBUTING.md) in the vscode-dev-containers repo.
+
 ## Build and Run
 
 If you want to understand how VS Code works or want to debug an issue, you'll want to get the source, build it, and run the tool locally.

--- a/How-to-Contribute.md
+++ b/How-to-Contribute.md
@@ -64,6 +64,15 @@ In case of issues, try deleting the contents of `~/.node-gyp` (alternatively `~/
 
 > If you have Visual Studio 2019 installed, you may face issues when using the default version of node-gyp. If you have Visual Studio 2019 installed, you may need to follow the solutions [here](https://github.com/nodejs/node-gyp/issues/1747)
 
+### Development container
+
+Alternatively, you can avoid local dependency installation as this repository includes a Visual Studio Code Remote - Containers / Codespaces [development container](https://github.com/microsoft/vscode/tree/master/.devcontainer).
+
+- For [Remote - Containers](https://aka.ms/vscode-remote/download/containers), use the **Remote-Containers: Open Repository in Container...** command which creates a Docker volume for better disk I/O on macOS and Windows.
+- For Codespaces, install the [Visual Studio Codespaces](https://aka.ms/vscs-ext-vscode) extension in VS Code, and use the **Codespaces: Create New Codespace** command.
+
+Docker / the Codespace should have at least **4 Cores and 6 GB of RAM (8 GB recommended)** to run full build. See the [development container README](https://github.com/microsoft/vscode/blob/master/.devcontainer/README.md) for more information.
+
 ## Build and Run
 
 If you want to understand how VS Code works or want to debug an issue, you'll want to get the source, build it, and run the tool locally.


### PR DESCRIPTION
While we have guidance in using the dev container on the [main readme](https://github.com/microsoft/vscode#development-container), a user was searching for it in the "How to Contribute" wiki, and it seems like it'd make sense to include it there as well.

See https://github.com/microsoft/vscode/issues/103293