### PR TITLE
g++ added to dependencies

### DIFF
--- a/How-to-Contribute.md
+++ b/How-to-Contribute.md
@@ -44,7 +44,7 @@ You'll need the following tools:
     * [pkg-config](https://www.freedesktop.org/wiki/Software/pkg-config/)
     * [GCC](https://gcc.gnu.org) or another compile toolchain
     * Dependencies for [native-keymap](https://www.npmjs.com/package/native-keymap) and [keytar](https://www.npmjs.com/package/keytar):
-      * On Debian-based Linux: `sudo apt-get install libx11-dev libxkbfile-dev libsecret-1-dev`
+      * On Debian-based Linux: `sudo apt-get install g++ libx11-dev libxkbfile-dev libsecret-1-dev`
       * On Red Hat-based Linux: `sudo yum install libX11-devel.x86_64 libxkbfile-devel.x86_64 libsecret-devel # or .i686`.
     * Building deb and rpm packages requires `fakeroot` and `rpm`, run: `sudo apt-get install fakeroot rpm`
 


### PR DESCRIPTION
Debain 10 Buster doesn't have g++ installed default, so running **yarn** fails because of it.