### PR TITLE
Install python-is-python3 on Debian

### DIFF
--- a/How-to-Contribute.md
+++ b/How-to-Contribute.md
@@ -40,7 +40,7 @@ You'll need the following tools:
     - [Xcode](https://developer.apple.com/xcode/downloads/) and the Command Line Tools, which will install `gcc` and the related toolchain containing `make`
       - Run `xcode-select --install` to install the Command Line Tools
   - **Linux**
-    * On Debian-based Linux: `sudo apt-get install build-essential g++ libx11-dev libxkbfile-dev libsecret-1-dev`
+    * On Debian-based Linux: `sudo apt-get install build-essential g++ libx11-dev libxkbfile-dev libsecret-1-dev python`
     * On Red Hat-based Linux: `sudo yum groupinstall "Development Tools" && sudo yum install libX11-devel.x86_64 libxkbfile-devel.x86_64 libsecret-devel # or .i686`.
     * Others:
       * `make`

--- a/How-to-Contribute.md
+++ b/How-to-Contribute.md
@@ -40,7 +40,7 @@ You'll need the following tools:
     - [Xcode](https://developer.apple.com/xcode/downloads/) and the Command Line Tools, which will install `gcc` and the related toolchain containing `make`
       - Run `xcode-select --install` to install the Command Line Tools
   - **Linux**
-    * On Debian-based Linux: `sudo apt-get install build-essential g++ libx11-dev libxkbfile-dev libsecret-1-dev python`
+    * On Debian-based Linux: `sudo apt-get install build-essential g++ libx11-dev libxkbfile-dev libsecret-1-dev python-is-python3`
     * On Red Hat-based Linux: `sudo yum groupinstall "Development Tools" && sudo yum install libX11-devel.x86_64 libxkbfile-devel.x86_64 libsecret-devel # or .i686`.
     * Others:
       * `make`


### PR DESCRIPTION
The `python` command is required to install `vscode-sqlite3` or else the postinstall script using `gyp` fails.

On newer versions of Ubuntu/Debiain, a `python` link does not exist by default, but can be installed with `python-is-python3`.

On Fedora, this is not necessary as `python-unversioned-command` is already installed by default (or at least after installing the existing dependencies listed) which points `python` to `python3`.

---

This PR originally installed Python 2 using the `python` package, before I saw PR #163 which stated that Python 3 works fine too.