### PR TITLE
Fix double preposition

### DIFF
--- a/How-to-Contribute.md
+++ b/How-to-Contribute.md
@@ -91,7 +91,7 @@ git pull https://github.com/microsoft/vscode.git master
 
 Manage any merge conflicts, commit them, and then push them to your fork.
 
-**Note**: The `microsoft/vscode` repository contains a collection of GitHub Actions that help us with triaging issues. As you probably don't want these running on your fork, you can disable Actions for your fork by via `https://github.com/<<Your Username>>/vscode/settings/actions`.
+**Note**: The `microsoft/vscode` repository contains a collection of GitHub Actions that help us with triaging issues. As you probably don't want these running on your fork, you can disable Actions for your fork via `https://github.com/<<Your Username>>/vscode/settings/actions`.
 
 ### Build
 


### PR DESCRIPTION
Removed the "by" next to "via" in line 94 of How-to-Contribute.md.

"By" implies that users are accessing information that is adjacent to the web address. "Via" implies that the information being directed to is contained within the web address. Both of them together would imply that the information is both adjacent and contained within the web address. Since the "actions" setting is held within the web address, only via should be used.