### PR TITLE
Fix broken link to community localization project page in "How To Contribute" page

### DIFF
--- a/How-to-Contribute.md
+++ b/How-to-Contribute.md
@@ -231,7 +231,7 @@ See also: [Cross-Compiling for Debian-based Linux](https://github.com/Microsoft/
 We're also interested in your feedback for the future of VS Code. You can submit a suggestion or feature request through the issue tracker. To make this process more effective, we're asking that these include more information to help define them more clearly.
 
 ## Translations
-We appreciate your localization contributions, either by providing new translations, voting on translations, or suggesting process improvements. We take translations through a community localization service, not through the vscode repo. See [our localization site](https://github.com/Microsoft/Localization/wiki) to get started.
+We appreciate your localization contributions, either by providing new translations, voting on translations, or suggesting process improvements. We take translations through a community localization service, not through the vscode repo. See [our localization site](https://github.com/microsoft/vscode-loc) to get started.
 
 ## Discussion Etiquette
 


### PR DESCRIPTION
### Issue
Current [link](https://github.com/Microsoft/Localization/wiki) to the community localization project page specified in the ["How To Contribute"](https://github.com/microsoft/vscode-wiki/blob/main/How-to-Contribute.md#translations) page is broken and points to a 404 page.
 
### Solution
Update link URL to the community localization project [repo page](https://github.com/microsoft/vscode-loc), as specified by the official VS Code [docs](https://code.visualstudio.com/docs/getstarted/locales#_can-i-contribute-to-a-language-packs-translations)

### Summary of changes
- Update relevant link URL in `How-to-Contribute.md`