### PR TITLE
Insiders release notes: fix commit log link

### DIFF
--- a/Insiders-Release-Notes.md
+++ b/Insiders-Release-Notes.md
@@ -4,10 +4,10 @@ The [Insiders build](https://code.visualstudio.com/blogs/2016/05/23/evolution-of
 
 Over the course of an iteration the contents of the Insiders builds will change frequently. Therefore, we do not produce a formal set of Release Notes. Instead, the following queries will help you explore the contents of a nightly build:
 
-* [Commit log](https://github.com/Microsoft/vscode/commits/main)
+* [Commit log](https://github.com/microsoft/vscode/commits/main)
 
-* [Recently closed issues](https://github.com/Microsoft/vscode/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed) 
+* [Recently closed issues](https://github.com/microsoft/vscode/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed) 
 
-* [Current month's iteration plan](https://github.com/Microsoft/vscode/issues?utf8=%E2%9C%93&q=is%3Aissue+label%3Aiteration-plan+)
+* [Current month's iteration plan](https://github.com/microsoft/vscode/issues?utf8=%E2%9C%93&q=is%3Aissue+label%3Aiteration-plan+)
 
-* [Current month's Release Notes on GitHub](https://github.com/Microsoft/vscode-docs/blob/vnext/release-notes)
+* [Current month's Release Notes on GitHub](https://github.com/microsoft/vscode-docs/blob/vnext/release-notes)


### PR DESCRIPTION
It looks like the `Microsoft` org name is lowercase now. Mostly this doesn't matter, but the commit log link is a 404 without switching to the lowercase `microsoft`. I changed all the links for consistency.