### PR TITLE
Clarify packaging instructions

### DIFF
--- a/How-to-Contribute.md
+++ b/How-to-Contribute.md
@@ -238,9 +238,7 @@ These `gulp` tasks are available:
 * `vscode-[platform]`: Builds a packaged version for `[platform]`.
 * `vscode-[platform]-min`: Builds a packaged and minified version for `[platform]`.
 
-You can run `gulp` via `yarn run`, for example
-
-    yarn run gulp vscode-linux-x64
+👉 **Tip!** Run `gulp` via `yarn` to avoid potential out of memory issues, for example `yarn gulp vscode-linux-x64`
 
 See also: [Cross-Compiling for Debian-based Linux](https://github.com/Microsoft/vscode/wiki/Cross-Compiling-for-Debian-Based-Linux)
 

--- a/How-to-Contribute.md
+++ b/How-to-Contribute.md
@@ -238,6 +238,10 @@ These `gulp` tasks are available:
 * `vscode-[platform]`: Builds a packaged version for `[platform]`.
 * `vscode-[platform]-min`: Builds a packaged and minified version for `[platform]`.
 
+You can run `gulp` via `yarn run`, for example
+
+    yarn run gulp vscode-linux-x64
+
 See also: [Cross-Compiling for Debian-based Linux](https://github.com/Microsoft/vscode/wiki/Cross-Compiling-for-Debian-Based-Linux)
 
 ## Suggestions


### PR DESCRIPTION
It wasn't clear that I couldn't just run `gulp vscode-linux-x64`. I mean I guess that works if you have gulp installed globally but it isn't in the dev container. `yarn run gulp` works though.