### PR TITLE
Update _Sidebar.md - removed "Requested Extensions"

### DIFF
--- a/_Sidebar.md
+++ b/_Sidebar.md
@@ -29,7 +29,6 @@
 * [[Coding Guidelines]]
 * [[Smoke Test]]
 * [[Contributor License Agreement]]
-* [Requested Extensions](https://github.com/Microsoft/vscode/wiki/Requested-Extensions)
 * [[Extension API Guidelines]]
 
 **Documentation**


### PR DESCRIPTION
Removed link to the "Requested Extensions" as there is no such page anymore.
It seemed this was the only broken link 👍. At least in the sidebar.