### PR TITLE
Add more detailed explanation for incremental builder

### DIFF
--- a/How-to-Contribute.md
+++ b/How-to-Contribute.md
@@ -119,9 +119,9 @@ yarn
 Then you have two options:
 
 - If you want to build from inside VS Code, you can open the `vscode` folder and start the build task with <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>B</kbd> (<kbd>CMD</kbd>+<kbd>Shift</kbd>+<kbd>B</kbd> on macOS). The build task will stay running in the background even if you close VS Code. If you happen to close VS Code and open it again, just resume the build by pressing <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>B</kbd> (<kbd>CMD</kbd>+<kbd>Shift</kbd>+<kbd>B</kbd>) again. You can kill it by running the `Kill Build VS Code` task or pressing <kbd>Ctrl</kbd>+<kbd>D</kbd> in the task terminal.
-- If you want to build from a terminal, run `yarn watch`.
+- If you want to build from a terminal, run `yarn watch`. This will run both the core watch task and watch-extension tasks in a single terminal.
 
-The incremental builder will do an initial full build and will display a message that includes the phrase like "[watch-client] Finished compilation" in addition to "[watch-extension] Finished compilation" once the initial build is complete. The builder will watch for file changes and compile those changes incrementally, giving you a fast, iterative coding experience.
+The incremental builder will do an initial full build and will display a message that includes the phrase "Finished compilation" once the initial build is complete. The builder will watch for file changes and compile those changes incrementally, giving you a fast, iterative coding experience.
 
 **Troubleshooting:**
 

--- a/How-to-Contribute.md
+++ b/How-to-Contribute.md
@@ -121,7 +121,7 @@ Then you have two options:
 - If you want to build from inside VS Code, you can open the `vscode` folder and start the build task with <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>B</kbd> (<kbd>CMD</kbd>+<kbd>Shift</kbd>+<kbd>B</kbd> on macOS). The build task will stay running in the background even if you close VS Code. If you happen to close VS Code and open it again, just resume the build by pressing <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>B</kbd> (<kbd>CMD</kbd>+<kbd>Shift</kbd>+<kbd>B</kbd>) again. You can kill it by running the `Kill Build VS Code` task or pressing <kbd>Ctrl</kbd>+<kbd>D</kbd> in the task terminal.
 - If you want to build from a terminal, run `yarn watch`.
 
-The incremental builder will do an initial full build and will display a message that includes the phrase "Finished compilation" once the initial build is complete. The builder will watch for file changes and compile those changes incrementally, giving you a fast, iterative coding experience.
+The incremental builder will do an initial full build and will display a message that includes the phrase like "[watch-client] Finished compilation" in addition to "[watch-extension] Finished compilation" once the initial build is complete. The builder will watch for file changes and compile those changes incrementally, giving you a fast, iterative coding experience.
 
 **Troubleshooting:**
 


### PR DESCRIPTION
With this PR, I’ve added detailed explanation in How-to-Contribute.md that say what kind of message indicates the build is complete.  
Since the current doc only says "Finished compilation" but in reality there are 2 type of messages that include the phrase “Finished compilation”.  And actually until the 2nd message that includes “watch-client” show up, the build was not complete.

1. [watch-extensions] [13:51:53] Finished compilation extensions with 0 errors after 61114 ms
2. [watch-client    ] [13:53:11] Finished compilation with 0 errors after 138074 ms

When I saw the 1st message showed up, I misunderstood the build was complete and did command `./scripts/code.sh` but had the below error. And it takes a few minutes that the 2nd message shows up. For example it takes 138074 ms on my dev machine(MacBook Pro 2020, 2GHz quad core Intel Core i5, 32GB memory). In this situation developers tend to think if their build step is something wrong even if it's not.

```
[Error: ENOENT: no such file or directory, open '/Users/username/works/vscode/out/vs/code/node/cli.js'] {
  errno: -2,
  code: 'ENOENT',
  syscall: 'open',
  path: '/Users/username/works/vscode/out/vs/code/node/cli.js',
  phase: 'loading',
  moduleId: 'vs/code/node/cli',
  neededBy: [ '===anonymous1===' ]
}
```

It’s important for newcomers to know right message indicates the build is complete to avoid unnecessary effort looking the wiki over and over again with thinking if they are wrong.