### PR TITLE
Fix link to Microsoft's documentation for WSL2 installation

### DIFF
--- a/Selfhosting-on-Windows-WSL.md
+++ b/Selfhosting-on-Windows-WSL.md
@@ -10,7 +10,7 @@ The drawback is that running VS Code from sources actually runs on **Linux** whi
 
 In Windows:
 
-1. Install [WSL2](https://docs.microsoft.com/en-us/windows/wsl/wsl2-install) and [Ubuntu](https://www.microsoft.com/en-us/p/ubuntu/9nblggh4msv6?activetab=pivot:overviewtab).
+1. Install [WSL2](https://docs.microsoft.com/en-us/windows/wsl/install) and [Ubuntu](https://www.microsoft.com/en-us/p/ubuntu/9nblggh4msv6?activetab=pivot:overviewtab).
 2. Install [vcxsrv](https://sourceforge.net/projects/vcxsrv/), it will create a `XLaunch` shortcut in your Desktop`.
 3. Download the `config.xlaunch` file from [this gist](https://gist.github.com/joaomoreno/90d3915379a862d99cd4f3e79feb0f8a) to your user home directory `C:\Users\USERNAME\`.
 3. Hit <kbd>Win R</kbd> and type `shell:startup`, hit <kbd>Enter</kbd>. Add a shortcut here for `C:\Program Files\VcXsrv\xlaunch.exe`.


### PR DESCRIPTION
#203 
The link to Microsoft's documentation for WSL2 installation in Selfhosting-on-Windows-WSL.md is obsolete. This pull request just switches the link to https://docs.microsoft.com/en-us/windows/wsl/install.