### PR TITLE
fix(how-to-contribute): remove --launch

### DIFF
--- a/How-to-Contribute.md
+++ b/How-to-Contribute.md
@@ -147,7 +147,7 @@ Code for the Web (Extensions run in the browser):
 Web with Code Server (Extensions run in code server):
 
 ```bash
-./scripts/code-server.sh|bat --launch
+./scripts/code-server.sh|bat
 ```
 
 You can identify the development version of VS Code ("Code - OSS") by the following icon in the Dock or Taskbar:


### PR DESCRIPTION
`--launch` is no longer used when running `./scripts/code-server.sh` (or so it appears)

Error message:

```sh
➜  vscode git:(main) ./scripts/code-server.sh|bat --launch
error: Found argument '--launch' which wasn't expected, or isn't valid in this context
```