### PR TITLE
Update Feedback Channels to include GitHub Discussions

### DIFF
--- a/Feedback-Channels.md
+++ b/Feedback-Channels.md
@@ -10,8 +10,8 @@ Notice, we don't want to use GitHub Issues for general 'how-to' questions about 
 
 >Therefore please do not be upset when we close an issue with the comment to ask a question on Stack Overflow. 
 
-## GitHub discussions
-[GitHub discussions](https://github.com/microsoft/vscode-discussions/discussions) provides a place where the community can get together and collaborate. It is the official place to discuss VS Code's extension platform, ask questions, help other members of the community, and get answers.
+## GitHub Discussions
+[GitHub Discussions](https://github.com/microsoft/vscode-discussions/discussions) provides a place where the community can get together and collaborate. It is the official place to discuss VS Code's extension platform, ask questions, help other members of the community, and get answers.
 
 The VS Code PM and Advocacy teams have a presence in this community, periodicially posting announcements and answering questions.
 

--- a/Feedback-Channels.md
+++ b/Feedback-Channels.md
@@ -1,4 +1,4 @@
-As a development team we want to be present on many channels (GitHub issues, Twitter, Stack Overflow, Gitter). We want to be responsive and at the same time be effective, for example, we want to avoid having to provide the same answer on different channels. This page describes how the development team intends to use and be active on the different channels.
+As a development team we want to be present on many channels (GitHub issues, Twitter, Stack Overflow, GitHub Discussions). We want to be responsive and at the same time be effective, for example, we want to avoid having to provide the same answer on different channels. This page describes how the development team intends to use and be active on the different channels.
 
 ## GitHub issues
 [GitHub issues](https://github.com/Microsoft/vscode/issues) should be used for bugs and feature requests. How to submit good bugs and feature requests is described in [How to Contribute](https://github.com/Microsoft/vscode/blob/master/CONTRIBUTING.md) and how we track issues is described in [[Issue Tracking]].
@@ -10,10 +10,10 @@ Notice, we don't want to use GitHub Issues for general 'how-to' questions about 
 
 >Therefore please do not be upset when we close an issue with the comment to ask a question on Stack Overflow. 
 
-## Gitter Chat Room
-The [Gitter Channel](https://gitter.im/Microsoft/vscode) provides a place where the Community can get together and collaborate. It is actually great to see that folks have already started to collaborate and support each other there. 
+## GitHub discussions
+[GitHub discussions](https://github.com/microsoft/vscode-discussions/discussions) provides a place where the community can get together and collaborate. It is the official place to discuss VS Code's extension platform, ask questions, help other members of the community, and get answers.
 
-The VS Code team's presence in the room will be optional, at least for the foreseeable future. We hope the Community will use the room and have discussions.
+The VS Code PM and Advocacy teams have a presence in this community, periodicially posting announcements and answering questions.
 
 ## Slack
 The [Visual Studio Code Development Community](https://aka.ms/vscode-dev-community) Slack workspace is a community maintained place for VS Code contributors, extension developers, theme authors, etc to help one another and collaborate. This Slack workspace contains many discussion channels including many for specific extensions.
@@ -23,7 +23,7 @@ Here are a few of the main channels: (you must first [join the Slack workspace](
 - [vscode-extensions-dev](https://vscode-dev-community.slack.com/messages/C74CB59NE) for discussions about extension development.
 - [vscode-themes](https://vscode-dev-community.slack.com/messages/CBQAQ5GAD/) for discussions about theme authoring.
 
-Just like the Gitter room, the VS Code team's presence in this Slack workspace will be optional, at least for the foreseeable future.
+The VS Code team's presence in this Slack workspace will be optional, at least for the foreseeable future.
 
 ## Twitter
 Watch for tweets from the [**@code**](https://twitter.com/code) account on twitter for announcements and updates from members of the development team.


### PR DESCRIPTION
A new [GH discussions](https://github.com/microsoft/vscode-discussions/discussions) forum has been created for VS Code. Additionally, the Gitter community is not a particularly active community, so this PR replaces the Gitter section with GH Discussions.

Once this is approved, I will also send a chat in the Gitter community to point them in the direction of the slack/GH discussion communities instead.