### PR TITLE
Added mention for Node 17 that can be used

### DIFF
--- a/How-to-Contribute.md
+++ b/How-to-Contribute.md
@@ -11,6 +11,7 @@ You'll need the following tools:
 
 - [Git](https://git-scm.com)
 - [Node.JS](https://nodejs.org/en/), **x64**, version `>=16.14.x and <17`
+  - Node version `>=17` can be used, but it's still untested.
 - [Yarn](https://yarnpkg.com/en/), follow the [installation guide](https://yarnpkg.com/en/docs/install)
 - [Python](https://www.python.org/downloads/) (required for node-gyp; check the [node-gyp readme](https://github.com/nodejs/node-gyp#installation) for the currently supported Python versions)
   - **Note:** Python will be automatically installed for Windows users through installing `windows-build-tools` npm module (see below)


### PR DESCRIPTION
After https://github.com/Microsoft/vscode/commit/345c867437a66324204f9bf429c2b6ff96302b38 it is no longer forbidden to use Node >=17, can be used but at your own risk.

Added this mention in the docs.