### PR TITLE
Clarify yarn version range

### DIFF
--- a/How-to-Contribute.md
+++ b/How-to-Contribute.md
@@ -11,7 +11,7 @@ You'll need the following tools:
 
 - [Git](https://git-scm.com)
 - [Node.JS](https://nodejs.org/en/), **x64**, version `>=16.14.x and <17`
-- [Yarn](https://yarnpkg.com/en/), follow the [installation guide](https://yarnpkg.com/en/docs/install)
+- [Yarn 1](https://classic.yarnpkg.com/en/), version `>=1.10.1 and <2`, follow the [installation guide](https://classic.yarnpkg.com/en/docs/install)
 - [Python](https://www.python.org/downloads/) (required for node-gyp; check the [node-gyp readme](https://github.com/nodejs/node-gyp#installation) for the currently supported Python versions)
   - **Note:** Python will be automatically installed for Windows users through installing `windows-build-tools` npm module (see below)
 - A C/C++ compiler tool chain for your platform:


### PR DESCRIPTION
Also update links to no longer rely on redirects (the old links are redirecting to these new links).