### PR TITLE
How-to-Contribute.md: fix launch configuration's name

### DIFF
--- a/How-to-Contribute.md
+++ b/How-to-Contribute.md
@@ -186,7 +186,7 @@ The **render** process runs the UI code inside the Shell window. To debug code r
 
 #### Using VS Code
 * Open the `vscode` repository folder
-* Choose the `Launch VS Code` launch configuration from the launch dropdown in the Debug viewlet and press <kbd>F5</kbd>.
+* Choose the `VS Code` launch configuration from the launch dropdown in the Debug viewlet and press <kbd>F5</kbd>.
 
 
 #### Using the Chrome Developer Tools


### PR DESCRIPTION
Hello!

"VS Code": 

```json
	"compounds": [
		{
			"name": "VS Code",
			"configurations": [
				"Launch VS Code",
				"Attach to Main Process",
				"Attach to Extension Host",
				"Attach to Shared Process",
			],
			"presentation": {
				"group": "0_vscode",
				"order": 1
			}
		},
```

https://github.com/microsoft/vscode/blob/5252b76e2b5c7f12ddd1dc8e234673e015d428de/.vscode/launch.json#L362