### PR TITLE
Modifies heading hierarchy in Build and Run section to be clearer

### DIFF
--- a/How-to-Contribute.md
+++ b/How-to-Contribute.md
@@ -123,18 +123,18 @@ To test the changes, you launch a development version of VS Code on the workspac
 
 To test changes with a remote, use the "TestResolver" in your Code - OSS window which creates a fake remote window. Search Command Palette for `TestResolver`. More information is at https://github.com/microsoft/vscode/issues/162874#issuecomment-1271774905.
 
-### Desktop
+#### Desktop
 
 Running on Electron with extensions run in NodeJS:
 
-**macOS and Linux**
+##### macOS and Linux
 
 ```bash
 ./scripts/code.sh
 ./scripts/code-cli.sh # for running CLI commands (eg --version)
 ```
 
-**Windows**
+##### Windows
 
 ```bat
 .\scripts\code.bat
@@ -143,34 +143,34 @@ Running on Electron with extensions run in NodeJS:
 
 👉 **Tip!** If you receive an error stating that the app is not a valid Electron app, it probably means you didn't run `yarn watch` first.
 
-### VS Code for the Web
+#### VS Code for the Web
 
 Extensions and UI run in the browser.
 
 👉 Besides `yarn watch` also run `yarn watch-web` to build the web bits for the built-in extensions.
 
-**macOS and Linux**
+##### macOS and Linux
 
 ```bash
 ./scripts/code-web.sh
 ```
 
-**Windows**
+##### Windows
 
 ```bat
 .\scripts\code-web.bat
 ```
-### Code Server Web
+#### Code Server Web
 
 UI in the browser, extensions run in code server (NodeJS):
 
-**macOS and Linux**
+##### macOS and Linux
 
 ```bash
 ./scripts/code-server.sh --launch
 ```
 
-**Windows**
+##### Windows
 
 ```bat
 .\scripts\code-server.bat --launch


### PR DESCRIPTION
I noticed that some of the heading hierarchy for the `How-to-Contribute.md` file isn't too clear in the "Build and Run" section, specifically the '**Run**' heading in that section had an 'H3 Heading' font while its sub-sections of _'Desktop'_, _'VS Code for the Web'_, and _'Code Server Web'_ had the same heading level so it wasn't that clear they were sub-sections. 

I modified the subsections to be H4 instead and also modified some of the sub-sections within there to be H5 to better distinguish themselves.