### PR TITLE
Added missing word in Semantic-Highlighting-Overview.md

### DIFF
--- a/Semantic-Highlighting-Overview.md
+++ b/Semantic-Highlighting-Overview.md
@@ -26,7 +26,7 @@ The server takes a while to load and analyze the project, that's why the highlig
 Currently semantic highlighting is only offered by TypeScript, JavaScript as well as JavaScript in HTML.
 More languages will adopt. The semantic token provider API is now available for all since 1.44.
 
-If you are a language extension and want to implement a semantic token provider, please check out the [sample](https://github.com/Microsoft/vscode-extension-samples/tree/master/semantic-tokens-sample).
+If you are a language extension author and want to implement a semantic token provider, please check out the [sample](https://github.com/Microsoft/vscode-extension-samples/tree/master/semantic-tokens-sample).
 
 ### Which themes offer semantic highlighting
 


### PR DESCRIPTION
Replaced 'If you are a language extension' with 'If you are a language extension author'.