### PR TITLE
Build instructions: add krb5 to dependencies

### DIFF
--- a/How-to-Contribute.md
+++ b/How-to-Contribute.md
@@ -29,8 +29,8 @@ You'll need the following tools:
     - [Xcode](https://developer.apple.com/xcode/downloads/) and the Command Line Tools, which will install `gcc` and the related toolchain containing `make`
       - Run `xcode-select --install` to install the Command Line Tools
   - **Linux**
-    * On Debian-based Linux: `sudo apt-get install build-essential g++ libx11-dev libxkbfile-dev libsecret-1-dev python-is-python3`
-    * On Red Hat-based Linux: `sudo yum groupinstall "Development Tools" && sudo yum install libX11-devel.x86_64 libxkbfile-devel.x86_64 libsecret-devel # or .i686`.
+    * On Debian-based Linux: `sudo apt-get install build-essential g++ libx11-dev libxkbfile-dev libsecret-1-dev libkrb5-dev python-is-python3`
+    * On Red Hat-based Linux: `sudo yum groupinstall "Development Tools" && sudo yum install libX11-devel.x86_64 libxkbfile-devel.x86_64 libsecret-devel krb5-devel # or .i686`.
     * Others:
       * `make`
       * [pkg-config](https://www.freedesktop.org/wiki/Software/pkg-config/)


### PR DESCRIPTION
This PR adds Kerberos to the `sudo apt install ...` dependency list.

Without it, I got the following error when running `yarn`:

```text
  CXX(target) Release/obj.target/kerberos/src/kerberos.o
In file included from ../src/kerberos_common.h:5,
                 from ../src/kerberos.h:12,
                 from ../src/kerberos.cc:1:
../src/unix/kerberos_gss.h:21:14: fatal error: gssapi/gssapi.h: No such file or directory
   21 |     #include <gssapi/gssapi.h>
      |              ^~~~~~~~~~~~~~~~~
compilation terminated.
make: *** [kerberos.target.mk:128: Release/obj.target/kerberos/src/kerberos.o] Error 1
```

And after `sudo apt install libkrb5-dev`, things worked as expected.