### PR TITLE
Update Roadmap.md file to fix the Bracket Pair Colorizer broken link due to the first iteration of the extension not existing anymore.

### DIFF
--- a/Roadmap.md
+++ b/Roadmap.md
@@ -257,7 +257,7 @@ We have a dedicated [Python Roadmap](https://github.com/microsoft/vscode-python/
 - [ ] :runner: [ES Lint](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint)
 - [ ] :runner: [Markdown customization extensions](https://marketplace.visualstudio.com/items?itemName=bierner.github-markdown-preview)
 
-- [x] [Bracket Pair Colorizer](https://marketplace.visualstudio.com/items?itemName=CoenraadS.bracket-pair-colorizer)
+- [x] [Bracket Pair Colorizer](https://marketplace.visualstudio.com/items?itemName=CoenraadS.bracket-pair-colorizer-2)
 
 
 ## Install / Update


### PR DESCRIPTION
This commit changes the link for the bracket pair colorizer extension in the current roadmap to point to the new iteration of the extension. This is done as the first iteration of the extension is no longer on the marketplace, meaning that the link is now broken, resulting in the user encountering a 404 page when they visit the link in the previous commit.