### PR TITLE
Fix typos in Automated Issue Triaging page

### DIFF
--- a/Automated-Issue-Triaging.md
+++ b/Automated-Issue-Triaging.md
@@ -104,12 +104,12 @@ The feature requests bot serves to implement our [feature request triaging pipel
 
 All issues which have the `needs more info` label, haven't been interacted with 7 days, and were last interacted with by a team member are closed.
 
-If an issue has the `needs more info`, hasn't been interacted with in 60 days, and was last interacted with by a non-team member, the bot will comment pinging the issue assignee to take a look at the issue to ensure it doesn't "slip though the cracks".
+If an issue has the `needs more info`, hasn't been interacted with in 60 days, and was last interacted with by a non-team member, the bot will comment pinging the issue assignee to take a look at the issue to ensure it doesn't "slip through the cracks".
 
 ## Locker
 [Source](https://github.com/microsoft/vscode-github-triage-actions/tree/stable/locker)
 
-Issue which have been closed for 45 days and have not been interacted with in 3 days are locked. If the issue has the label `author-verification-requested` and does not have the label `verified`, it will not be locked. If the issue has the label `*out-of-scope`, it will not be locked.
+Issues which have been closed for 45 days and have not been interacted with in 3 days are locked. If the issue has the label `author-verification-requested` and does not have the label `verified`, it will not be locked. If the issue has the label `*out-of-scope`, it will not be locked.
 
 ## English Please
 [Source](https://github.com/microsoft/vscode-github-triage-actions/tree/stable/english-please) | [Examples](https://github.com/microsoft/vscode/issues?q=is%3Aissue+is%3Aclosed+label%3Atranslation-required-portuguese-brazil)

--- a/Automated-Issue-Triaging.md
+++ b/Automated-Issue-Triaging.md
@@ -167,7 +167,7 @@ Applies labels to issues that either do or do not match a particular regex. For 
 # <a name="closing-with-a-commit"></a>Closing Issues "With a Commit"
 [Source](https://github.com/microsoft/vscode-github-triage-actions/blob/56b9db6aa5ee879108139b1252b2903d2478e2a2/api/octokit.ts#L366-L447) | [Example "\closedWith"](https://github.com/microsoft/vscode/issues/124134#issuecomment-843640354)
 
-Various pipelines work better when an issue is closed "with a commit" and we can perform operations using the SHA associated with the closing of the issue. The SHA used for the operation is in the timeline's last post:
+Various pipelines work best when an issue is closed "with a commit" and we can perform operations using the SHA associated with the closing of the issue. The SHA used for the operation is in the timeline's last post:
   - Commit with the `Closes/Fixes #NUM` GitHub syntax put on `main`
   - PR marked as `Closes/Fixes #NUM` merged into `main`
   - Comment with `\closedWith {SHA}` made by a team member

--- a/Automated-Issue-Triaging.md
+++ b/Automated-Issue-Triaging.md
@@ -102,7 +102,7 @@ The feature requests bot serves to implement our [feature request triaging pipel
 ## Needs More Info
 [Source](https://github.com/microsoft/vscode-github-triage-actions/tree/stable/needs-more-info-closer) | [Example](https://github.com/microsoft/vscode/issues/123535#issuecomment-838615068)
 
-All issues which have the `needs more info` label, haven't been interacted with 7 days, and were last interacted with by a team member are closed.
+All issues which have the `needs more info` label, haven't been interacted with 7 for days, and were last interacted with by a team member are closed.
 
 If an issue has the `needs more info`, hasn't been interacted with in 60 days, and was last interacted with by a non-team member, the bot will comment pinging the issue assignee to take a look at the issue to ensure it doesn't "slip through the cracks".
 
@@ -166,7 +166,8 @@ Applies labels to issues that either do or do not match a particular regex. For 
 
 # <a name="closing-with-a-commit"></a>Closing Issues "With a Commit"
 [Source](https://github.com/microsoft/vscode-github-triage-actions/blob/56b9db6aa5ee879108139b1252b2903d2478e2a2/api/octokit.ts#L366-L447) | [Example "\closedWith"](https://github.com/microsoft/vscode/issues/124134#issuecomment-843640354)
-Various pipelines work best when an issue is closed "with a commit" and we can perform operations using the SHA associated with the closing of the issue. The SHA used for the operation in is the timeline's last most:
+
+Various pipelines work better when an issue is closed "with a commit" and we can perform operations using the SHA associated with the closing of the issue. The SHA used for the operation is in the timeline's last post:
   - Commit with the `Closes/Fixes #NUM` GitHub syntax put on `main`
   - PR marked as `Closes/Fixes #NUM` merged into `main`
   - Comment with `\closedWith {SHA}` made by a team member


### PR DESCRIPTION
Fix typos in [Automated Issue Triaging page](https://github.com/microsoft/vscode-wiki/blob/main/Automated-Issue-Triaging.md)

Specifically:
- "slip though the cracks" -> "slip through the cracks"
- Issue which have been [...] -> Issues which have been [...] 
- haven't been interacted with 7 days [..] -> haven't been interacted with for 7 days [...]
- Various pipelines work best when [...] -> Various pipelines work better when [...]
- The SHA used for the operation in is the timeline [...] -> The SHA used for the operation is in the timeline [...]