### PR TITLE
Fix typos in Build champion page

### DIFF
--- a/Build-Champion.md
+++ b/Build-Champion.md
@@ -42,7 +42,7 @@ If this was a recent failure and the "Changes" seems relevant, ping the committe
 
 It is crucial for our success to have a green insiders build from `main` branch that gets published to our [update site](https://builds.code.visualstudio.com/builds/insider) at least once on a day. Various tools depend on this to happen, for example performance testing to figure out performance regressions early. 
 
-Insider builds are scheduled to running daily automatically. In case of failure, it is your responsibility to act accordingly:
+Insider builds are scheduled to run daily automatically. In case of failure, it is your responsibility to act accordingly:
 * when automated release is disabled (debt week): run the [pipeline](https://monacotools.visualstudio.com/DefaultCollection/Monaco/_build?definitionId=111) but do not release the build
 * when automated release is enabled (otherwise): run the [pipeline](https://monacotools.visualstudio.com/DefaultCollection/Monaco/_build?definitionId=111) and release the build
 

--- a/Build-Champion.md
+++ b/Build-Champion.md
@@ -46,7 +46,7 @@ Insider builds are scheduled to running daily automatically. In case of failure,
 * when automated release is disabled (debt week): run the [pipeline](https://monacotools.visualstudio.com/DefaultCollection/Monaco/_build?definitionId=111) but do not release the build
 * when automated release is enabled (otherwise): run the [pipeline](https://monacotools.visualstudio.com/DefaultCollection/Monaco/_build?definitionId=111) and release the build
 
-👉 even in debt week, when the automated release is disabled, we still want the daily insiders build to succeed (but not released!). this ensures our daily rhythm is not impacted at all and we can act on build issues early on
+👉 even in debt week, when the automated release is disabled, we still want the daily insiders build to succeed (but not released!). This ensures our daily rhythm is not impacted at all and we can act on build issues early on.
 
 
 ## Triage error telemetry


### PR DESCRIPTION
Fix typos in [Build champion page](https://github.com/microsoft/vscode-wiki/blob/main/Build-Champion.md).

Specifically:

- Insider builds are scheduled to running daily automatically. -> Insider builds are scheduled to run daily automatically. 
- Non capitalized starting words
- Missing end of sentence punctuation 