### PR TITLE
Fix typos in Contributor license Agreement page

### DIFF
--- a/Contributor-License-Agreement.md
+++ b/Contributor-License-Agreement.md
@@ -1,4 +1,4 @@
-You must sign a [Contribution License Agreement (CLA)](https://cla.opensource.microsoft.com/) before your PR will be merged. This a one-time requirement for Microsoft projects on GitHub. You can read more about [Contribution License Agreements](https://en.wikipedia.org/wiki/Contributor_License_Agreement) on Wikipedia.
+You must sign a [Contribution License Agreement (CLA)](https://cla.opensource.microsoft.com/) before your PR will be merged. This is a one-time requirement for Microsoft projects on GitHub. You can read more about [Contribution License Agreements](https://en.wikipedia.org/wiki/Contributor_License_Agreement) on Wikipedia.
 
 However, you don't have to do this up-front; you can simply clone, fork, and submit your pull-request as usual.
 


### PR DESCRIPTION
Fix typos in [Contributor license Agreement page](https://github.com/microsoft/vscode-wiki/blob/main/Contributor-License-Agreement.md)

Specifically: 

- This a one-time requirement [...] -> This is a one-time requirement [...]