### PR TITLE
Fix typos in Dev perf performance error page

### DIFF
--- a/[dev-perf]-PerformanceError-and-unresponsive-renderer-telemetry.md
+++ b/[dev-perf]-PerformanceError-and-unresponsive-renderer-telemetry.md
@@ -1,6 +1,6 @@
 ## Automatic renderer profiling
 
-The renderer process is monitored for "hangs" and when those occur automatic profiling is started. It works as follows
+The renderer process is monitored for "hangs" and when those occur automatic profiling is started. It works as follows:
 
 * after startup a performance baseline is computed (on fast machines this is fine-tuned to be roughly one frame at 64fps, 15ms)
 * when a [long task](https://developer.mozilla.org/en-US/docs/Web/API/PerformanceLongTaskTiming) that is 10x of the baseline is reported, automatic renderer profiling is started (for 5secs)

--- a/[dev-perf]-PerformanceError-and-unresponsive-renderer-telemetry.md
+++ b/[dev-perf]-PerformanceError-and-unresponsive-renderer-telemetry.md
@@ -9,7 +9,7 @@ The renderer process is monitored for "hangs" and when those occur automatic pro
 
 #### Dealing with `PerfSampleError` error
 
-As mentioned above, hangs are reported as normal- and error-telemetry. When the a certain error event is reported many times it shows up on our error triage page. The error shows a synthetic stacktrace which is the callstack that the profiler saw most often. The top is the slow function and the calls is how it was called. 
+As mentioned above, hangs are reported as normal- and error-telemetry. When a certain error event is reported many times it shows up on our error triage page. The error shows a synthetic stacktrace which is the callstack that the profiler saw most often. The top is the slow function and the calls is how it was called. 
 
 If the error telemetry isn't sufficient you can dig into telemetry. Use the query below but make sure use the right version of VSCode and filter for the name of your function. _Note_ that only stable versions of VS Code yield usable results. That is because insiders generates too little data. The query will show how many machines were affected and what the average hang-time was. 
 

--- a/[dev-perf]-PerformanceError-and-unresponsive-renderer-telemetry.md
+++ b/[dev-perf]-PerformanceError-and-unresponsive-renderer-telemetry.md
@@ -11,7 +11,7 @@ The renderer process is monitored for "hangs" and when those occur automatic pro
 
 As mentioned above, hangs are reported as normal- and error-telemetry. When a certain error event is reported many times it shows up on our error triage page. The error shows a synthetic stacktrace which is the callstack that the profiler saw most often. The top is the slow function and the calls is how it was called. 
 
-If the error telemetry isn't sufficient you can dig into telemetry. Use the query below but make sure use the right version of VSCode and filter for the name of your function. _Note_ that only stable versions of VS Code yield usable results. That is because insiders generates too little data. The query will show how many machines were affected and what the average hang-time was. 
+If the error telemetry isn't sufficient you can dig into telemetry. Use the query below but make sure to use the right version of VSCode and filter for the name of your function. _Note_ that only stable versions of VS Code yield usable results. That is because insiders generates too little data. The query will show how many machines were affected and what the average hang-time was. 
 
 ```js
 RawEventsVSCode


### PR DESCRIPTION
Fix typos in [Dev perf performance error page](https://github.com/microsoft/vscode-wiki/blob/main/%5Bdev-perf%5D-PerformanceError-and-unresponsive-renderer-telemetry.md)

Specifically:

- [...] make sure use the right version [...] -> [...] make sure to use the right version [...]
- When the a certain error event is reported [...] -> When a certain error event is reported [...]
- Adds end of sentence punctuation 