### PR TITLE
Fix typos and improve text consistency of Extension api guidelines page

### DIFF
--- a/Extension-API-guidelines.md
+++ b/Extension-API-guidelines.md
@@ -23,7 +23,7 @@ Events aren’t defined on the types they occur on but in the best matching name
 
 Private Events
 -
-Private or instance events aren't accessible via globals but exist on objects, e.g., `FileSystemWatcher#onDidCreate`.  *Don't* use private events unless the sender of the event is private. The rule of thumb is: 'Objects that can be accessed globally (editors, tasks, terminals, documents, etc)' should not have private events, objects that are private (only known by its creators, like tree views, web views) can send private events' 
+Private or instance events aren't accessible via globals but exist on objects, e.g., `FileSystemWatcher#onDidCreate`.  *Don't* use private events unless the sender of the event is private. The rule of thumb is: 'Objects that can be accessed globally (editors, tasks, terminals, documents, etc)' should not have private events, objects that are private (only known by its creators, like tree views, web views) can send private events.
 
 Event naming
 -
@@ -100,7 +100,7 @@ We define the API with strictNull-checks in mind. That means we use the optional
 
 Undefined is False
 -
-The default value of an optional, boolean property is `false`. This is for consistency with JS where undefined never evaluates to `true`
+The default value of an optional, boolean property is `false`. This is for consistency with JS where undefined never evaluates to `true`.
 
 JSDOC
 -

--- a/Extension-API-guidelines.md
+++ b/Extension-API-guidelines.md
@@ -23,7 +23,7 @@ Events aren’t defined on the types they occur on but in the best matching name
 
 Private Events
 -
-Private or instance events aren't accessible via globals but exist on objects, e.g., `FileSystemWatcher#onDidCreate`.  *Don't* use private events unless the sender of the event is private. The rule of thumb is: 'Objects that can be accessed globally (editors, tasks, terminals, documents, etc)' should not have private events, objects that are private (only known by its creators, like tree views, web views) can send private events.
+Private or instance events aren't accessible via globals but exist on objects, e.g., `FileSystemWatcher#onDidCreate`.  *Don't* use private events unless the sender of the event is private. The rule of thumb is: 'Objects that can be accessed globally (editors, tasks, terminals, documents, etc) should not have private events, objects that are private (only known by its creators, like tree views, web views) can send private events'.
 
 Event naming
 -

--- a/Extension-API-guidelines.md
+++ b/Extension-API-guidelines.md
@@ -108,7 +108,7 @@ We add JSDoc for all parts of the API. The doc is supported by markdown syntax. 
 
 # Optional parameters (`?` vs `| undefined`)
 - For implementation, treat omitting a parameter with `?` the same as explicitly passing in `undefined`
-- Use `| undefined` when you want to callers to always have to consider the parameter. 
+- Use `| undefined` when you want callers to always have to consider the parameter. 
 - Use `?` when you want to allow callers to omit the parameter. 
 - Never use `?` and `| undefined` on a parameter. Instead follow the two rules above to decide which version to use .
 - If adding a new parameter to an existing function, use `?` as this allows the new signature to be backwards compatible with the old version.
@@ -119,7 +119,7 @@ We add JSDoc for all parts of the API. The doc is supported by markdown syntax. 
 - Do not write code that treats the absence of a property differently than a property being present but set to `undefined`
     - This can sometimes hit you on spreads or iterating through objects, so just something to be aware of
 
-- For readonly properties on interfaces that VS Code exposes to extensions (this include managed objects, as well as the objects passed to events):
+- For readonly properties on interfaces that VS Code exposes to extensions (this includes managed objects, as well as the objects passed to events):
     - Use `| undefined` as this makes it clear the property exists but has the value `undefined`. 
   
 - For readonly properties on options bag type objects passed from extensions to VS Code:

--- a/Extension-API-guidelines.md
+++ b/Extension-API-guidelines.md
@@ -108,11 +108,11 @@ We add JSDoc for all parts of the API. The doc is supported by markdown syntax. 
 
 # Optional parameters (`?` vs `| undefined`)
 - For implementation, treat omitting a parameter with `?` the same as explicitly passing in `undefined`
-- Use `| undefined` when you want callers to always have to consider the parameter. 
-- Use `?` when you want to allow callers to omit the parameter. 
-- Never use `?` and `| undefined` on a parameter. Instead follow the two rules above to decide which version to use .
-- If adding a new parameter to an existing function, use `?` as this allows the new signature to be backwards compatible with the old version.
-- Do not add an overload to add an optional parameter to the end of the function. Instead use `?`.
+- Use `| undefined` when you want callers to always have to consider the parameter
+- Use `?` when you want to allow callers to omit the parameter
+- Never use `?` and `| undefined` on a parameter. Instead follow the two rules above to decide which version to use
+- If adding a new parameter to an existing function, use `?` as this allows the new signature to be backwards compatible with the old version
+- Do not add an overload to add an optional parameter to the end of the function. Instead use `?`
 
 # Optional properties (`?` vs `| undefined`)
 
@@ -120,7 +120,7 @@ We add JSDoc for all parts of the API. The doc is supported by markdown syntax. 
     - This can sometimes hit you on spreads or iterating through objects, so just something to be aware of
 
 - For readonly properties on interfaces that VS Code exposes to extensions (this includes managed objects, as well as the objects passed to events):
-    - Use `| undefined` as this makes it clear the property exists but has the value `undefined`. 
+    - Use `| undefined` as this makes it clear the property exists but has the value `undefined`
   
 - For readonly properties on options bag type objects passed from extensions to VS Code:
     -  Use `?` when it is ok to omit the property


### PR DESCRIPTION
Fix typos and improve text consistency of the [Extension API Guidelines page](https://github.com/microsoft/vscode-wiki/blob/main/Extension-API-guidelines.md)