### PR TITLE
Docs: Fix Node.js spelling and 64-bit formatting

### DIFF
--- a/How-to-Contribute.md
+++ b/How-to-Contribute.md
@@ -13,7 +13,7 @@ In order to download necessary tools, clone the repository, and install dependen
 You'll need the following tools:
 
 - [Git](https://git-scm.com)
-- [Node.JS](https://nodejs.org/en/download/prebuilt-binaries), **x64** or **ARM64**, version `>=20.x` (also see [`.nvmrc`](https://github.com/microsoft/vscode/blob/main/.nvmrc), which may provide a more precise version to install)
+- [Node.js](https://nodejs.org/en/download/prebuilt-binaries), **x64** or **ARM64**, version `>=20.x` (also see [`.nvmrc`](https://github.com/microsoft/vscode/blob/main/.nvmrc), which may provide a more precise version to install)
   - If using `nvm`, consider updating your default node installation with `nvm alias default <VERSION>`
   - Windows:
     - Do not pick the option to install Windows Build Tools, see the step below for instructions
@@ -71,7 +71,7 @@ Make sure you cloned `vscode` into a folder without any spaces in the path hiera
 
 In case of issues, try deleting the contents of `~/.node-gyp` (alternatively `~/.cache/node-gyp` for Linux, `~/Library/Caches/node-gyp/` for macOS, or `%USERPROFILE%\AppData\Local\node-gyp` for Windows) first and then run `git clean -xfd` and then try again.
 
-> If you are on Windows or Linux 64 bit systems and would like to compile to 32 bit, you'll need to set the `npm_config_arch` environment variable to `ia32` before running `npm`. This will compile all native node modules for a 32 bit architecture. Similarly, when cross-compiling for ARM, set `npm_config_arch` to `arm`.
+> If you are on Windows or Linux 64-bit systems and would like to compile to 32 bit, you'll need to set the `npm_config_arch` environment variable to `ia32` before running `npm`. This will compile all native node modules for a 32 bit architecture. Similarly, when cross-compiling for ARM, set `npm_config_arch` to `arm`.
 
 > [!NOTE]
 > For more information on how to install NPM modules globally on UNIX systems without resorting to `sudo`, refer to [this guide](http://www.johnpapa.net/how-to-use-npm-global-without-sudo-on-osx/).


### PR DESCRIPTION
This PR fixes two minor documentation typos in the How to Contribute guide.

Changes:
- Corrected the official spelling of Node.js
- Standardized 64-bit formatting

This is a documentation-only change with no functional impact.
Thanks for maintaining VS Code!